### PR TITLE
Add .reg-files and instructions for setting up File Explorer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,36 @@ So, I wrote my own.
 
 It is written in C++ and uses DirectX for rendering.
 
+## Command-line arguments
+
+Elucidisk can be started from command-line, to scan a certain **drive** or **folder** by passing the
+relevant path as an (optional) argument:
+
+    elucidisk [path-to-drive-or-folder]
+
+## File Explorer integration
+
+Included in the repo (and in recent release archives) is a folder `RegistryFiles`,
+containing a couple of *Windows Registry* (`.reg`) files:
+
+* [Add_Elucidisk_to_File_Explorer_context_menu.reg](RegistryFiles/Add_Elucidisk_to_File_Explorer_context_menu.reg)
+* [Remove_Elucidisk_from_File_Explorer_context_menu.reg](RegistryFiles/Remove_Elucidisk_from_File_Explorer_context_menu.reg)
+
+These files can be used to add / remove the following two *context-menu* entries
+in **Windows File Explorer**:
+
+* **Scan drive with Elucidisk**
+* **Scan folder with Elucidisk**
+
+To add these two *context-menu* entries, perform the following steps:
+1. Right-click the file `Add_Elucidisk_to_File_Explorer_context_menu.reg` and choose **Edit**.
+1. Inspect the file contents and make sure the 4 paths specifying `elucidisk.exe` are matching the location of where you installed Elucidisk on your PC (the preset path is `C:\Program Files\Elucidisk\elucidisk.exe`).
+1. (Optionally, rename the titles of these two *context-menu* entries to your liking.)
+1. Save the changes you made (if any).
+1. Finally, "merge" this `.reg` file into the registry, by double-clicking it (or by right-clicking it and choosing `Merge`).
+
+To remove the same context menu entries, simply merge the file `Remove_Elucidisk_from_File_Explorer_context_menu.reg` into the registry (there's no need to edit paths this file).
+
 ## Building Elucidisk
 
 Elucidisk uses [Premake](http://premake.github.io) to generate Visual Studio solutions. Note that Premake >= 5.0.0-beta8 is required.

--- a/RegistryFiles/Add_Elucidisk_to_File_Explorer_context_menu.reg
+++ b/RegistryFiles/Add_Elucidisk_to_File_Explorer_context_menu.reg
@@ -1,0 +1,15 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CLASSES_ROOT\Drive\shell\Elucidisk]
+@="Scan drive with Elucidisk"
+"Icon"="C:\\Program Files\\Elucidisk\\elucidisk.exe"
+
+[HKEY_CLASSES_ROOT\Drive\shell\Elucidisk\command]
+@="C:\\Program Files\\Elucidisk\\elucidisk.exe \"%1\""
+
+[HKEY_CLASSES_ROOT\Directory\shell\Elucidisk]
+@="Scan folder with Elucidisk"
+"Icon"="C:\\Program Files\\Elucidisk\\elucidisk.exe"
+
+[HKEY_CLASSES_ROOT\Directory\shell\Elucidisk\command]
+@="C:\\Program Files\\Elucidisk\\elucidisk.exe \"%1\""

--- a/RegistryFiles/Remove_Elucidisk_from_File_Explorer_context_menu.reg
+++ b/RegistryFiles/Remove_Elucidisk_from_File_Explorer_context_menu.reg
@@ -1,0 +1,7 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CLASSES_ROOT\Drive\shell\Elucidisk]
+[-HKEY_CLASSES_ROOT\Drive\shell\Elucidisk\command]
+
+[-HKEY_CLASSES_ROOT\Directory\shell\Elucidisk]
+[-HKEY_CLASSES_ROOT\Directory\shell\Elucidisk\command]

--- a/premake5.lua
+++ b/premake5.lua
@@ -368,10 +368,12 @@ newaction {
         mkdir(target_dir)
 
         -- Package the release and the pdbs separately.
-        os.chdir(src .. "/x64")
         if have_7z then
+            os.chdir(src .. "/x64")
             --exec(have_7z .. " a -r  " .. target_dir .. "elucidisk-v" .. version .. "-symbols.zip  *.pdb")
             exec(have_7z .. " a -r  " .. target_dir .. "elucidisk-v" .. version .. ".zip  *.exe")
+            os.chdir(code_dir)
+            exec(have_7z .. " a  " .. target_dir .. "elucidisk-v" .. version .. ".zip  RegistryFiles/*.reg")
         end
 
         -- Tidy up code directory.

--- a/premake5.lua
+++ b/premake5.lua
@@ -83,8 +83,11 @@ define_exe("elucidisk", "windowedapp")
 local any_warnings_or_failures = nil
 local msbuild_locations = {
     "c:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin",
+    "c:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin",
     "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin",
+    "c:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin",
     "c:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\MSBuild\\Current\\Bin",
+    "c:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Professional\\MSBuild\\Current\\Bin",
 }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Implements issue #9, by adding template _Windows Registry_ (`.reg`) files for installation and removal of **Windows File Explorer** context-menu entries for scanning a drive / folder with **Elucidisk**.

The README is updated with two new sections, describing how to use the (pre-existing, optional) _Command-line argument_ and the new `.reg`-files for _File Explorer integration_.

The two new `.reg`-files are located in a new subfolder `RegistryFiles/` within the repo, and this folder is now also included in release archives.

(Additionally, since I use **Visual Studio** _Professional_ instead of _Enterprise_, I made the Premake-script look for a **msbuild** executable from that **VS**-variant as well.)